### PR TITLE
Revert "apidocs - use older version of bash-doxygen due to upstream bug"

### DIFF
--- a/scriptmodules/admin/apidocs.sh
+++ b/scriptmodules/admin/apidocs.sh
@@ -18,7 +18,7 @@ function depends_apidocs() {
 }
 
 function sources_apidocs() {
-    gitPullOrClone "$md_build" https://github.com/Anvil/bash-doxygen.git master 35ec6ff6
+    gitPullOrClone "$md_build" https://github.com/Anvil/bash-doxygen.git
 }
 
 function build_apidocs() {


### PR DESCRIPTION
This reverts commit 6c62e3cd4d29e9df9ba4b93c040d5129293c1f36.

upstream is now fixed